### PR TITLE
perf: check for divisibility by small primes

### DIFF
--- a/generatePrimes.js
+++ b/generatePrimes.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+export function generatePrimes(count) {
+    const primes = [2]
+    let nextTest = 3
+    while (primes.length < count) {
+        if (!primes.some(p => nextTest % p === 0)) {
+            primes.push(nextTest)
+        }
+        nextTest++
+    }
+    return primes
+}

--- a/primeSearch.js
+++ b/primeSearch.js
@@ -111,8 +111,10 @@ function generateTest (tested, keyFrame) {
 function generateTests (tested, keyFrame, count) {
     let arr = []
     for (let i = 0; i < count; i++) {
-        arr.push(generateTest(tested, keyFrame))
-        tested.add(hash(arr[i]))
+        do {
+            arr[i] = generateTest(tested, keyFrame)
+            tested.add(hash(arr[i]))
+        } while (!isPossiblyPrime(arr[i]))
     }
     return arr
 }
@@ -225,11 +227,7 @@ export async function findPrime (original, sophie = false) {
         const tests = generateTests(tested, keyFrame, simultaneous)
 
         // Turn the tests into `openssl prime` processes, and wait for them to complete.
-        const result = await Promise.all(
-            tests
-                .filter(i => isPossiblyPrime(i))
-                .map(i => execPromise(`openssl prime ${i}`))
-        )
+        const result = await Promise.all(tests.map(i => execPromise(`openssl prime ${i}`)))
 
         // Filter out any of the results that are not prime.
         const successes = result.filter(i => !i.stdout.includes('not prime'))


### PR DESCRIPTION
In my tests, this results in the prime searching process running approximately twice as fast. I believe this happens because:

1. A very large proportion of the candidates can be eliminated by checking them for divisibility with the first 2,000 primes.
2. Checking against the first 2,000 primes is very fast, even when single threaded in JavaScript.
3. Calling out to OpenSSL via the terminal adds considerable overhead/latency

## Benchmarks on the sample image (higher is better)

### The old code that always uses OpenSSL

36.7 prime candidates tested per second
37.5 prime candidates tested per second
33.7 prime candidates tested per second

### My version that first checks for divisibility by small primes

60.5 prime candidates tested per second
86.5 prime candidates tested per second
95.6 prime candidates tested per second
