### PR TITLE
Add ASCII export option

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 import { Command, Option } from 'commander'
 import { findPrime } from './primeSearch.js'
 import { transform } from './image.js'
+import { splitEvery } from "ramda";
 import commandExists from 'command-exists'
 
 import log from 'loglevel'
@@ -50,7 +51,7 @@ async function main () {
     else if (options.export === 'prime')
         log.info(result.prime)
     else
-        result.prime.match(new RegExp(`.{1,${options.width * 2}}`,'g')).forEach((line) => console.log(line))
+        console.log(splitEvery(options.width * 2, result.prime).join('\n'))
 }
 
 main().catch(err => {

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ import log from 'loglevel'
 const program = new Command()
 program.version('1.0.4').name('pictoprime').description('A program to find picture-esque primes. Requires openssl.')
 
-const outputOption = new Option('-x, --export <mode>', 'The output format').choices(['json', 'prime']).default('json')
+const outputOption = new Option('-x, --export <mode>', 'The output format').choices(['json', 'prime', 'ascii']).default('json')
 
 program
     .option('-n, --number <number>', 'The number to be transformed into a prime.')
-    .option('-i, --image <image>', 'Use an image to find primes.') 
+    .option('-i, --image <image>', 'Use an image to find primes.')
     .option('-q, --quiet', 'Hides some of the debug information to make it easier to get output from this program.')
     .addOption(outputOption)
     .option('--pixels <pixels>', 'The numbers to use to generate the prime (image mode). Left side is lighter, right side is darker.', '7772299408')
@@ -25,7 +25,7 @@ program
 
 program.parse(process.argv)
 
-/** @type {{ number: string, sophie: boolean, image?: string, pixels: string, width: string, contrast: string, video: string, export: 'json' | 'prime', quiet: boolean }} */
+/** @type {{ number: string, sophie: boolean, image?: string, pixels: string, width: string, contrast: string, video: string, export: 'json' | 'prime' | 'ascii', quiet: boolean }} */
 const options = program.opts()
 
 async function main () {
@@ -35,16 +35,22 @@ async function main () {
     if (!await commandExists('openssl').then(() => true).catch(() => false)) throw new Error('You must have openssl in your path for this program to work.')
 
     if (!options.number && !options.image) throw new Error('Either a number or an image must be specified.')
-    
+
     if (options.image) options.number = (await transform(options.image, {
         pixels: options.pixels,
         width: +options.width,
         contrast: +options.contrast
     })).replace(/\n/g, '')
 
-    
+
     const result = await findPrime(options.number, options.sophie)
-    log.info(options.export === 'json' ? JSON.stringify(result, undefined, 2) : result.prime)
+
+    if (options.export === 'json')
+        log.info(JSON.stringify(result,undefined,2))
+    else if (options.export === 'prime')
+        log.info(result.prime)
+    else
+        result.prime.match(new RegExp(`.{1,${options.width * 2}}`,'g')).forEach((line) => console.log(line))
 }
 
 main().catch(err => {

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Options:
   -n, --number <number>  The number to be transformed into a prime.
   -i, --image <image>    Use an image to find primes.
   -q, --quiet            Hides some of the debug information to make it easier to get output from this program.
-  -x, --export <mode>    The output format (choices: "json", "prime", "ascii" default: "json")
+  -x, --export <mode>    The output format (choices: "json", "prime", "ascii", default: "json")
   --pixels <pixels>      The numbers to use to generate the prime (image mode). Left side is lighter, right side is darker. (default: "7772299408")
   --width <width>        The width of the ascii to generate (image mode). (default: "32")
   --contrast <contrast>  Additional contrast to apply between -1.0 and 1.0 (image mode). (default: "0.1")

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Options:
   -n, --number <number>  The number to be transformed into a prime.
   -i, --image <image>    Use an image to find primes.
   -q, --quiet            Hides some of the debug information to make it easier to get output from this program.
-  -x, --export <mode>    The output format (choices: "json", "prime", default: "json")
+  -x, --export <mode>    The output format (choices: "json", "prime", "ascii" default: "json")
   --pixels <pixels>      The numbers to use to generate the prime (image mode). Left side is lighter, right side is darker. (default: "7772299408")
   --width <width>        The width of the ascii to generate (image mode). (default: "32")
   --contrast <contrast>  Additional contrast to apply between -1.0 and 1.0 (image mode). (default: "0.1")


### PR DESCRIPTION
add option to print on _stdout_ without any additional symbols and already with line breaks where they are supposed to be.